### PR TITLE
logscale and pyplot update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea/*
 
+# macOS stuff
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/hciplot/__init__.py
+++ b/hciplot/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 from .hciplot import plot_frames, plot_cubes

--- a/hciplot/hciplot.py
+++ b/hciplot/hciplot.py
@@ -1,23 +1,25 @@
-__author__ = 'Carlos Alberto Gomez Gonzalez, Valentin Christiaens'
+__author__ = 'Carlos Alberto Gomez Gonzalez, Valentin Christiaens, Iain Hammond'
 __all__ = ['plot_frames',
            'plot_cubes']
 
-from decimal import *
-import os
-import shutil
-import numpy as np
-import holoviews as hv
-from holoviews import opts
+from decimal import Decimal
+from os import mkdir
+from os.path import exists
+from shutil import rmtree
 from subprocess import call
-from matplotlib.pyplot import (figure, subplot, show, savefig, close, hlines,
-                               annotate)
-from matplotlib.patches import Circle, Ellipse
-from matplotlib.pyplot import colorbar as plt_colorbar
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+from warnings import filterwarnings
+
+import holoviews as hv
+import numpy as np
 from matplotlib.cm import register_cmap
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, ListedColormap, Normalize
-import warnings
-warnings.filterwarnings("ignore", module="matplotlib")
+from matplotlib.patches import Circle, Ellipse
+from matplotlib.pyplot import colorbar as plt_colorbar
+from matplotlib.pyplot import (figure, subplot, show, savefig, close, hlines,
+                               annotate)
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+filterwarnings("ignore", module="matplotlib")
 
 # Registering heat and cool colormaps from SaoImage DS9
 # borrowed from: https://gist.github.com/adonath/c9a97d2f2d964ae7b9eb
@@ -524,7 +526,7 @@ def plot_frames(data, backend='matplotlib', mode='mosaic', rows=1, vmax=None,
             raise ValueError("`mode` value was not recognized")
 
         for i, v in enumerate(range(num_plots)):
-            image = data[i].copy()
+            image = np.copy(data[i])
             frame_size = image.shape[0]  # assuming square frames
             cy = image.shape[0] / 2 - 0.5
             cx = image.shape[1] / 2 - 0.5
@@ -833,7 +835,7 @@ def plot_frames(data, backend='matplotlib', mode='mosaic', rows=1, vmax=None,
         # hv.opts(options)
 
         for i, v in enumerate(range(num_plots)):
-            image = data[i].copy()
+            image = np.copy(data[i])
             if vmin[i] is None:
                 vmin[i] = image.min()
             if vmax[i] is None:
@@ -930,9 +932,9 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
 
     Notes
     -----
-    http://holoviews.org/getting_started/Gridded_Datasets.html
-    http://holoviews.org/user_guide/Gridded_Datasets.html
-    http://holoviews.org/user_guide/Applying_Customizations.html
+    https://holoviews.org/getting_started/Gridded_Datasets.html
+    https://holoviews.org/user_guide/Gridded_Datasets.html
+    https://holoviews.org/user_guide/Applying_Customizations.html
     """
     hv.extension(backend)
 
@@ -985,7 +987,7 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             #options = "Image (cmap='" + cmap + "', interpolation='nearest',"
             #options += " clims=("+str(vmin)+','+str(vmax)+")"+")"
             #opts(options, image_stack)
-            return image_stack.opts(opts.Image(colorbar=colorbar,
+            return image_stack.opts(hv.opts.Image(colorbar=colorbar,
                                                cmap=cmap,
                                                clim=(vmin, vmax)))
             # hv.save(image_stack, 'holomap.gif', fps=5)
@@ -1008,7 +1010,7 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             else:
                 width_ = width
 
-            return image_stack.opts(opts.Image(colorbar=colorbar,
+            return image_stack.opts(hv.opts.Image(colorbar=colorbar,
                                                colorbar_opts={'width': 15,
                                                               'padding': 3},
                                                width=width_, height=height,
@@ -1059,10 +1061,10 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
                                          label_step_range[1],
                                          label_step_range[2])
 
-        if os.path.exists(dir_path):
-            shutil.rmtree(dir_path)
+        if exists(dir_path):
+            rmtree(dir_path)
             print('Replacing ' + dir_path)
-        os.mkdir(dir_path)
+        mkdir(dir_path)
 
         print('Producing each animation frame...')
         for i, labstep in zip(data_step_range, list(label_step_range)):
@@ -1072,15 +1074,15 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             plot_frames(cube[i], backend='matplotlib', mode='mosaic',
                         save=savelabel, dpi=dpi, vmin=vmin, vmax=vmax,
                         colorbar=colorbar, cmap=cmap,
-                        label=[label + str(labstep + 1)], **kwargs)
+                        label=tuple([label + str(labstep + 1)]), **kwargs)
         try:
             filename = anim_path + '.' + anim_format
             call(['convert', '-delay', str(delay), dir_path + '*.png',
                   filename])
-            if os.path.exists(filename):
+            if exists(filename):
                 print('Animation successfully saved to disk as ' + filename)
                 if delete_anim_cache:
-                    shutil.rmtree(dir_path)
+                    rmtree(dir_path)
                     print('Temp directory deleted ' + dir_path)
 
         except FileNotFoundError:

--- a/hciplot/hciplot.py
+++ b/hciplot/hciplot.py
@@ -9,8 +9,8 @@ from shutil import rmtree
 from subprocess import call
 from warnings import filterwarnings
 
-import holoviews as hv
 import numpy as np
+from holoviews import extension, Dataset, Image, Layout, output, opts
 from matplotlib.cm import register_cmap
 from matplotlib.colors import LinearSegmentedColormap, LogNorm, ListedColormap, Normalize
 from matplotlib.patches import Circle, Ellipse
@@ -829,7 +829,7 @@ def plot_frames(data, backend='matplotlib', mode='mosaic', rows=1, vmax=None,
             return fig, ax
 
     elif backend == 'bokeh':
-        hv.extension(backend)
+        extension(backend)
         subplots = []
         # options = "Image (cmap='" + custom_cmap[0] + "')"  # taking first item
         # hv.opts(options)
@@ -840,14 +840,14 @@ def plot_frames(data, backend='matplotlib', mode='mosaic', rows=1, vmax=None,
                 vmin[i] = image.min()
             if vmax[i] is None:
                 vmax[i] = image.max()
-            im = hv.Image((range(image.shape[1]), range(image.shape[0]), image))
+            im = Image((range(image.shape[1]), range(image.shape[0]), image))
             subplots.append(im.opts(tools=['hover'], colorbar=colorbar[i],
                                     colorbar_opts={'width': 15},
                                     width=width, height=height,
                                     clim=(vmin[i], vmax[i]),
                                     cmap=custom_cmap[0]))
 
-        return hv.Layout(subplots).cols(cols)
+        return Layout(subplots).cols(cols)
 
     else:
         raise ValueError('`backend` not supported')
@@ -936,7 +936,7 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
     https://holoviews.org/user_guide/Gridded_Datasets.html
     https://holoviews.org/user_guide/Applying_Customizations.html
     """
-    hv.extension(backend)
+    extension(backend)
 
     if not isinstance(cube, np.ndarray):
         raise TypeError('`cube` must be a numpy.ndarray')
@@ -955,15 +955,15 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             # Y is a 1D array of shape N and
             # Z is a 1D array of shape O
             # Data is a ND array of shape NxMxO
-            ds = hv.Dataset((range(cube.shape[2]), range(cube.shape[1]),
-                             range(cube.shape[0]), cube), ['x', 'y', 'time'],
-                            'flux')
+            ds = Dataset((range(cube.shape[2]), range(cube.shape[1]),
+                         range(cube.shape[0]), cube), ['x', 'y', 'time'],
+                         'flux')
             max_frames = cube.shape[0]
         elif cube.ndim == 4:
             # adding a lambda dimension
-            ds = hv.Dataset((range(cube.shape[3]), range(cube.shape[2]),
-                             range(cube.shape[1]), range(cube.shape[0]), cube),
-                            ['x', 'y', 'time', 'lambda'], 'flux')
+            ds = Dataset((range(cube.shape[3]), range(cube.shape[2]),
+                        range(cube.shape[1]), range(cube.shape[0]), cube),
+                        ['x', 'y', 'time', 'lambda'], 'flux')
             max_frames = cube.shape[0] * cube.shape[1]
 
         # Matplotlib takes None but not Bokeh. We take global min & max instead
@@ -976,9 +976,9 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
         print(":Cube_shape\t{}".format(list(cube.shape[::-1])))
 
         # not working for bokeh: dpi
-        image_stack = ds.to(hv.Image, kdims=['x', 'y'], dynamic=dynamic)
-        hv.output(backend=backend, size=size, dpi=dpi, fig=figtype,
-                  max_frames=max_frames)
+        image_stack = ds.to(Image, kdims=['x', 'y'], dynamic=dynamic)
+        output(backend=backend, size=size, dpi=dpi, fig=figtype,
+               max_frames=max_frames)
 
         if backend == 'matplotlib':
             # keywords in the currently active 'matplotlib' renderer are:
@@ -987,7 +987,7 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             #options = "Image (cmap='" + cmap + "', interpolation='nearest',"
             #options += " clims=("+str(vmin)+','+str(vmax)+")"+")"
             #opts(options, image_stack)
-            return image_stack.opts(hv.opts.Image(colorbar=colorbar,
+            return image_stack.opts(opts.Image(colorbar=colorbar,
                                                cmap=cmap,
                                                clim=(vmin, vmax)))
             # hv.save(image_stack, 'holomap.gif', fps=5)
@@ -1010,7 +1010,7 @@ def plot_cubes(cube, mode='slider', backend='matplotlib', dpi=100,
             else:
                 width_ = width
 
-            return image_stack.opts(hv.opts.Image(colorbar=colorbar,
+            return image_stack.opts(opts.Image(colorbar=colorbar,
                                                colorbar_opts={'width': 15,
                                                               'padding': 3},
                                                width=width_, height=height,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-matplotlib<=3.4.3
+matplotlib
 holoviews
 bokeh<3.2.0,>=3.1.1
 panel


### PR DESCRIPTION
This change is to address two nuisances in plot_frames, i) the behaviour of `vmin` and `vmax` is deprecated and limits the code to matplotlib<=3.4.3, and ii) by forcing all numbers to be positive in the case of `logscale`, the limits entered by the user are _not_ those displayed in the final image. This is in contrast to FITS viewers like DS9, Qfitsview and Carta. 

These new changes bring the code up to date and make it behave the same as if the user was viewing the image in a FITS viewer, which can be helpful for quickly determining the best cuts and scale. `LogNorm` and `Normalize` are imported directly as passed `vmin` and `vmax` from the user. If no `vmax` is provided, the largest valid number is used. If `vmin` is not provided or is <=0 in the case of `logscale`, two orders of magnitude are displayed by default. The version has also been bumped, and .DS_Store added to gitignore. I've tested it (matplotlib 3.7.2) on lots of data (SPHERE, NACO) including PDI data with negative values and logscaling and everything has worked so far :) it's completely backwards compatible, but in the case of hardcoded limits and logscaling when an image had negative values it will appear slightly differently and the limits will need to be readjusted. Bonus: sped up imports, fixed URLs and fixed a bug related to the labels in plot_cubes